### PR TITLE
Add humor warning

### DIFF
--- a/HUMOR_WARNING.md
+++ b/HUMOR_WARNING.md
@@ -1,0 +1,7 @@
+# Humoristic Intent and Security Implications
+
+Please note that 'getpublickey' is a humoristic creation meant for satirical purposes and not a legitimate security tool. Blindly obtaining a public key from an unverified server is not a best practice in cybersecurity. It's essential to verify the authenticity of a server's public key to ensure secure communication and prevent potential attacks. Always consult with cybersecurity professionals and utilize recognized, reputable tools and practices when dealing with the security of digital assets. The simplicity of the one-liner provided below demonstrates the program's playful nature rather than its practicality in real-world security scenarios.
+
+```bash
+echo | openssl s_client -connect google.com:443 2>/dev/null | openssl x509 -text
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Welcome to getpublickey - Your Gateway to Cybersecurity Excellence
 
+[**HUMOR_WARNING - Read first**](HUMOR_WARNING.md)
+
 ## Table of content:
 
   - [Introduction](#introduction)


### PR DESCRIPTION
Issue:
It looks like the superlatives used in the README file to describe a K8s server that fetches public keys, where not clear enough conveying the message that the text is humorous.  Blindly getting public keys form insecure servers is NOT a good practice :-)

Fix:
add a HUMOR_WARNING.md
